### PR TITLE
Add inference jobs list with vRAM estimates

### DIFF
--- a/inference_pipeline.sub
+++ b/inference_pipeline.sub
@@ -23,11 +23,11 @@ when_to_transfer_output = ON_EXIT
 request_memory = 8GB
 # need space for the container (3GB) as well
 request_disk = 10GB
-request_cpus = 4
+request_cpus = 1
 request_gpus = 1
 
 # Use the CHTC recommended AF3 memory requirement based on the number of tokens
-gpus_minimum_memory = 15 GB
+gpus_minimum_memory = $(AF3_vRAM) GB
 
 # short jobs 4-6 hours so it is okay to use is_resumable
 +GPUJobLength = "short"
@@ -41,4 +41,4 @@ want_ospool = true
 # arguments = --model_param_file af3.bin.zst --work_dir_ext $(Cluster)_$(Process) --user-specified-alphafold-options "--buckets 5982"
 arguments = --model_param_file af3.bin.zst --work_dir_ext $(Cluster)_$(Process)
 
-queue my_directory from list_of_af3_jobs.txt
+queue my_directory,AF3_vRAM from list_of_af3_inference_jobs.txt

--- a/scripts/generate-job-directories.py
+++ b/scripts/generate-job-directories.py
@@ -25,6 +25,7 @@ Usage:
 import os
 import csv
 import json
+import math
 import argparse
 
 
@@ -124,6 +125,11 @@ def main():
         help="Path to write job directory list (default: ./list_of_af3_jobs.txt)",
     )
     parser.add_argument(
+        "--inference_jobs_list",
+        default="./list_of_af3_inference_jobs.txt",
+        help="Path to write inference job list with vRAM estimates (default: ./list_of_af3_inference_jobs.txt)",
+    )
+    parser.add_argument(
         "--seed",
         nargs="+",
         default=[1],
@@ -136,6 +142,9 @@ def main():
 
     jobs_list_path = args.jobs_list
     jobs_list_file = open(jobs_list_path, "w")
+
+    inference_jobs_list_path = args.inference_jobs_list
+    inference_jobs_list_file = open(inference_jobs_list_path, "w")
 
     with open(args.manifest, newline="") as csvfile:
         reader = csv.DictReader(csvfile)
@@ -194,9 +203,14 @@ def main():
 
             jobs_list_file.write(f"{job_dir_name}\n")
 
+            vram_gb = max(7, math.ceil(estimated_vram_gb))
+            inference_jobs_list_file.write(f"{job_dir_name},{vram_gb}\n")
+
     jobs_list_file.close()
+    inference_jobs_list_file.close()
     print("\nAll multi-molecule AF3 job directories generated.")
     print("\nThe list of job directories has been written to:", jobs_list_path)
+    print("The inference job list has been written to:", inference_jobs_list_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a new CLI option --inference_jobs_list to write a second output file containing job directory names paired with rounded vRAM estimates. Import math, compute vRAM as ceil(estimated_vram_gb) with a minimum of 7 GB, write lines as job_dir_name,vram_gb, close the file, and print its path. This provides an easy-to-consume inference job list for scheduling or resource planning.